### PR TITLE
Fixing the Notion URL

### DIFF
--- a/src/content/pages/index.mdx
+++ b/src/content/pages/index.mdx
@@ -1477,7 +1477,7 @@ The README file contains Actor documentation written in [Markdown](https://docs.
 
 The README file is referenced from the [Actor file](#actor-file) using the `readme` property, and typically stored at `.actor/README.md`.
 
-Good documentation makes good Actors. [Read the Apify Actor marketing playbook](https://docs.apify.com/academy/get-most-of-actors/seo-and-promotion) for tips on how to write great READMEs and market Actors.
+Good documentation makes good Actors. [Read the Apify Actor marketing playbook](https://apify.notion.site/3fdc9fd4c8164649a2024c9ca7a2d0da?v=6d262c0b026d49bfa45771cd71f8c9ab) for tips on how to write great READMEs and market Actors.
 
 ### Input schema file
 


### PR DESCRIPTION
Based on the discussion in https://github.com/apify/actor-whitepaper/pull/59#pullrequestreview-2592926047, the URL of the Notion page has been changed.