### PR TITLE
Integrate FirstPromoter tracking

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,6 +1,7 @@
 ---
 import { HEAD } from '../config/components';
 import type { ISEOMetadata } from '../types/seo';
+import FirstPromoterTracker from './FirstPromoterTracker.astro';
 
 export interface Props extends ISEOMetadata {
     title: string;
@@ -20,11 +21,11 @@ const siteDomain = Astro.url.origin;
     http-equiv="Content-Security-Policy"
     content="
     default-src 'self';
-    script-src 'self' https://plausible.io https://unpkg.com 'unsafe-inline' 'unsafe-eval' blob:;
+    script-src 'self' https://plausible.io https://unpkg.com https://cdn.firstpromoter.com 'unsafe-inline' 'unsafe-eval' blob:;
     style-src 'self' https://fonts.googleapis.com 'unsafe-inline';
-    img-src 'self' data: blob:;
+    img-src 'self' data: blob: https://firstpromoter.com;
     font-src 'self' https://fonts.gstatic.com https://apify.com data:;
-    connect-src 'self' https://plausible.io https://prod.spline.design https://www.gstatic.com https://unpkg.com https://api.github.com;
+    connect-src 'self' https://plausible.io https://prod.spline.design https://www.gstatic.com https://unpkg.com https://api.github.com https://firstpromoter.com;
     base-uri 'self';
     form-action 'self';
     upgrade-insecure-requests;
@@ -123,11 +124,15 @@ const siteDomain = Astro.url.origin;
 
 {
     import.meta.env.MODE === 'production' && (
-        <script
-            defer
-            data-domain="whitepaper.actor"
-            data-category="analytics"
-            src="https://plausible.io/js/script.hash.js"
-        />
+        <>
+            <script
+                defer
+                data-domain="whitepaper.actor"
+                data-category="analytics"
+                src="https://plausible.io/js/script.hash.js"
+            />
+
+            <FirstPromoterTracker />
+        </>
     )
 }

--- a/src/components/FirstPromoterTracker.astro
+++ b/src/components/FirstPromoterTracker.astro
@@ -1,0 +1,54 @@
+<script
+    defer
+    src="https://cdn.firstpromoter.com/fprom.js"
+    onload="console.log('[FirstPromoter] Script loaded')"
+    onerror="console.error('[FirstPromoter] Failed to load script')"></script>
+
+<script>
+    import { createLogger, type ILogger } from '../utils/logger';
+    const logger: ILogger = createLogger({ prefix: 'FirstPromoter' });
+
+    /**
+     * Track the FirstPromoter referral.
+     *
+     * This function checks if the referral parameter is present in the URL. If it is, it sets the referral in local
+     * storage and removes it from the URL. If the referral parameter is not present, it logs a message.
+     */
+    function trackFirstPromoterReferral() {
+        // Get the referral parameter from the URL.
+        const mainUrlParams = new URLSearchParams(window.location.search);
+        const hashUrlParams = new URLSearchParams(window.location.hash.split('?')[1] || '');
+        const fprParam = mainUrlParams.get('fpr') || hashUrlParams.get('fpr');
+
+        // If the referral parameter is present, set it in local storage and remove it from the URL.
+        if (fprParam) {
+            localStorage.setItem('fpr_referral', fprParam);
+            logger.info(`Referral tracked: ${fprParam}`);
+
+            // Remove the referral parameter from the URL.
+            if (mainUrlParams.has('fpr')) {
+                // Remove the referral parameter from the URL.
+                mainUrlParams.delete('fpr');
+
+                const newUrl = `${window.location.pathname}${mainUrlParams.toString() ? `?${mainUrlParams.toString()}` : ''}${window.location.hash}`;
+
+                // Replace the current URL with the new URL.
+                window.history.replaceState({}, '', newUrl);
+            } else if (window.location.hash.includes('?')) {
+                // Remove the referral parameter from the URL.
+                hashUrlParams.delete('fpr');
+
+                // Replace the current URL with the new URL.
+                const newHash = window.location.hash.split('?')[0];
+                const newUrl = `${window.location.pathname}${window.location.search}${newHash}${hashUrlParams.toString() ? `?${hashUrlParams.toString()}` : ''}`;
+
+                // Replace the current URL with the new URL.
+                window.history.replaceState({}, '', newUrl);
+            }
+        } else {
+            logger.info('No FirstPromoter referral found, no action taken');
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', trackFirstPromoterReferral);
+</script>


### PR DESCRIPTION
Add `FirstPromoterTracker` component to `BaseHead` for referral tracking. Update Content Security Policy to include FirstPromoter domains.

The new component loads the FirstPromoter script and tracks referral parameters, storing them in local storage and removing them from the URL. This enhances our analytics capabilities by integrating with FirstPromoter's system.

Fixes #84 